### PR TITLE
Allow disabling rDNS lookup.

### DIFF
--- a/bookshelf/api_v1.py
+++ b/bookshelf/api_v1.py
@@ -151,6 +151,18 @@ def arch():
     return result
 
 
+def disable_openssh_rdns(distribution):
+    log_green('Disabling openssh reverse dns lookups')
+    openssh_config_file = '/etc/ssh/sshd_config'
+    dns_config = 'UseDNS no'
+    if not file_contains(openssh_config_file, dns_config, use_sudo=True):
+        file_append(openssh_config_file, dns_config, use_sudo=True)
+        service_name = 'sshd'
+        if 'ubuntu' in distribution:
+            service_name = 'ssh'
+        sudo('service {} reload'.format(service_name))
+
+
 def cache_docker_image_locally(docker_image):
     # download docker images to speed up provisioning
     log_green('pulling docker image %s locally' % docker_image)

--- a/bookshelf/api_v1.py
+++ b/bookshelf/api_v1.py
@@ -152,6 +152,22 @@ def arch():
 
 
 def disable_openssh_rdns(distribution):
+    """
+    Set 'UseDNS no' in openssh config to disable rDNS lookups
+
+    On each request for a new channel openssh defaults to an
+    rDNS lookup on the client IP. This can be slow, if it fails
+    for instance, adding 10s of overhead to every request
+    for a new channel (not connection). This can add a lot of
+    time to a process that opens lots of channels (e.g. running
+    several commands via fabric.)
+
+    This function will disable rDNS lookups in the openssh
+    config and reload ssh to adjust the running instance.
+
+    :param bytes distribution: the name of the distribution
+        running on the node.
+    """
     log_green('Disabling openssh reverse dns lookups')
     openssh_config_file = '/etc/ssh/sshd_config'
     dns_config = 'UseDNS no'


### PR DESCRIPTION
This can be very costly when it fails because it takes a few
seconds to timeout. This happens whenever a new channel (not connection)
is created, which can really add up if that happens a lot (e.g. with fabric).
