### PR TITLE
Gce round 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,12 @@ matrix:
   fast_finish: true
 
 env:
-  - TEST_SUITE=test_pkg.py
-  - TEST_SUITE=test_file.py
-  - TEST_SUITE=test_java.py
-  - TEST_SUITE=test_git.py
-  - TEST_SUITE=test_python.py
+  - TEST_SUITE=api_v2/test_pkg.py
+  - TEST_SUITE=api_v2/test_file.py
+  - TEST_SUITE=api_v2/test_java.py
+  - TEST_SUITE=api_v2/test_git.py
+  - TEST_SUITE=api_v2/test_python.py
+  - TEST_SUITE=api_v3/test_interfaces.py
   # we can't run vagrant on Travis.CI, as it uses OpenVZ
   # so we need to skip the docker tests for now
   # - TEST_SUITE=test_docker.py
@@ -30,4 +31,4 @@ env:
 install:
   - pip install .
 
-script: "python bookshelf/tests/api_v2/$TEST_SUITE"
+script: "python bookshelf/tests/$TEST_SUITE"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ env:
 install:
   - pip install .
 
-script: "python bookshelf/tests/$TEST_SUITE"
+script: "export PYTHONPATH=`pwd` && python bookshelf/tests/$TEST_SUITE"

--- a/README.mdown
+++ b/README.mdown
@@ -32,3 +32,20 @@ To run tests do:
     python2 bookshelf/api_v2/test_ec2.py
     python2 bookshelf/api_v2/test_rackspace.py
 
+There are also tests for the api_v3 that spin up GCE, Rackspace, and EC2
+instances. These tests require credentials to access GCE, Rackspace, and EC2.
+In an effort to attempt to reduce the amount of work to set up the
+configuration, they build on the existing acceptance.yml as described at:
+http://doc-dev.clusterhq.com/gettinginvolved/appendix.html#acceptance-testing-configuration.
+
+Note that instead of starting from that configuration, you can start with an
+empty yml file and the tests will print out what configuration you need to add
+in to your yaml file in order to run the tests.
+
+To run these tests do:
+
+    export ACCEPTANCE_YAML=/path/to/your/acceptance.yml
+    virtualenv venv
+    . venv/bin/activate
+    pip install -r requirements.txt
+    python2 bookshelf/tests/api_v3/test_cloud.py

--- a/bookshelf/api_v1.py
+++ b/bookshelf/api_v1.py
@@ -9,7 +9,7 @@ import socket
 import sys
 import uuid
 from time import time, sleep
-from pprint  import pformat
+from pprint import pformat
 
 from boto.ec2.blockdevicemapping import BlockDeviceMapping, EBSBlockDeviceType
 from oauth2client.client import GoogleCredentials
@@ -425,6 +425,7 @@ def gce_wait_until_done(operation):
 
 def get_gce_instance_config(instance_name, project, zone, machine_type, image,
                             username, public_key, disk_name=None):
+    public_key = open(public_key, 'r').read()
     if disk_name:
         disk_config = {
             "type": "PERSISTENT",
@@ -513,6 +514,8 @@ def startup_gce_instance(instance_name, project, zone, username, machine_type,
         body=instance_config
     ).execute()
     result = gce_wait_until_done(operation)
+    print "HIHI"
+    print result
     if not result:
         raise RuntimeError("Creation of VM timed out or returned no result")
     log_green("Instance has booted")
@@ -1702,6 +1705,10 @@ def save_gce_state_locally(instance_name,
         'zone': zone,
         'instance_name': instance_name,
     }
+    print "HERE"
+    print env.user
+    print "==="
+    print env.key_filename
     data['distribution'] = linux_distribution(username, ip_address)
     data['os_release'] = os_release(username, ip_address)
     return _save_state_locally(data)

--- a/bookshelf/api_v1.py
+++ b/bookshelf/api_v1.py
@@ -514,8 +514,6 @@ def startup_gce_instance(instance_name, project, zone, username, machine_type,
         body=instance_config
     ).execute()
     result = gce_wait_until_done(operation)
-    print "HIHI"
-    print result
     if not result:
         raise RuntimeError("Creation of VM timed out or returned no result")
     log_green("Instance has booted")
@@ -1705,10 +1703,6 @@ def save_gce_state_locally(instance_name,
         'zone': zone,
         'instance_name': instance_name,
     }
-    print "HERE"
-    print env.user
-    print "==="
-    print env.key_filename
     data['distribution'] = linux_distribution(username, ip_address)
     data['os_release'] = os_release(username, ip_address)
     return _save_state_locally(data)

--- a/bookshelf/api_v1.py
+++ b/bookshelf/api_v1.py
@@ -459,7 +459,7 @@ def get_gce_instance_config(instance_name, project, zone, machine_type, image,
         "networkInterfaces": [
             {
                 "network": (
-                    "projects/clusterhq-acceptance/global/networks/default"
+                    "projects/%s/global/networks/default" % project
                 ),
                 "accessConfigs": [
                     {

--- a/bookshelf/api_v2/ec2.py
+++ b/bookshelf/api_v2/ec2.py
@@ -1,5 +1,6 @@
 # vim: ai ts=4 sts=4 et sw=4 ft=python fdm=indent et
 
+import boto.ec2
 
 from boto.ec2.blockdevicemapping import BlockDeviceMapping, EBSBlockDeviceType
 from fabric.api import env
@@ -7,6 +8,17 @@ from time import sleep
 from bookshelf.api_v2.time_helpers import sleep_for_one_minute
 from bookshelf.api_v2.logging_helpers import log_green, log_yellow, log_red
 from bookshelf.api_v2.cloud import wait_for_ssh
+
+
+def connect_to_ec2(region, access_key_id, secret_access_key):
+    """ returns a connection object to AWS EC2  """
+    conn = boto.ec2.connect_to_region(region,
+                                      aws_access_key_id=access_key_id,
+                                      aws_secret_access_key=secret_access_key)
+    if conn:
+        return conn
+    else:
+        return False
 
 
 def create_ami(connection,
@@ -39,6 +51,68 @@ def create_ami(connection,
         return False
 
 
+def create_server_ec2(connection,
+                      region,
+                      disk_name,
+                      disk_size,
+                      ami,
+                      key_pair,
+                      instance_type,
+                      tags={},
+                      security_groups=None,
+                      delete_on_termination=True,
+                      log=False,
+                      wait_for_ssh_available=True):
+    """
+    Creates EC2 Instance
+    """
+
+    if log:
+        log_green("Started...")
+        log_yellow("...Creating EC2 instance...")
+
+    ebs_volume = EBSBlockDeviceType()
+    ebs_volume.size = disk_size
+    bdm = BlockDeviceMapping()
+    bdm[disk_name] = ebs_volume
+
+    # get an ec2 ami image object with our choosen ami
+    image = connection.get_all_images(ami)[0]
+    # start a new instance
+    reservation = image.run(1, 1,
+                            key_name=key_pair,
+                            security_groups=security_groups,
+                            block_device_map=bdm,
+                            instance_type=instance_type)
+
+    # and get our instance_id
+    instance = reservation.instances[0]
+
+    #  and loop and wait until ssh is available
+    while instance.state == u'pending':
+        if log:
+            log_yellow("Instance state: %s" % instance.state)
+        sleep(10)
+        instance.update()
+    if log:
+        log_green("Instance state: %s" % instance.state)
+    if wait_for_ssh_available:
+        wait_for_ssh(instance.public_dns_name)
+
+    # update the EBS volumes to be deleted on instance termination
+    if delete_on_termination:
+        for dev, bd in instance.block_device_mapping.items():
+            instance.modify_attribute('BlockDeviceMapping',
+                                      ["%s=%d" % (dev, 1)])
+
+    # add a tag to our instance
+    connection.create_tags([instance.id], tags)
+
+    if log:
+        log_green("Public dns: %s" % instance.public_dns_name)
+
+    # returns our new instance
+    return instance
 
 
 def destroy_ebs_volume(connection, region, volume_id, log=False):

--- a/bookshelf/api_v2/ec2.py
+++ b/bookshelf/api_v2/ec2.py
@@ -39,68 +39,6 @@ def create_ami(connection,
         return False
 
 
-def create_server_ec2(connection,
-                      region,
-                      disk_name,
-                      disk_size,
-                      ami,
-                      key_pair,
-                      instance_type,
-                      tags={},
-                      security_groups=None,
-                      delete_on_termination=True,
-                      log=False,
-                      wait_for_ssh_available=True):
-    """
-    Creates EC2 Instance
-    """
-
-    if log:
-        log_green("Started...")
-        log_yellow("...Creating EC2 instance...")
-
-    ebs_volume = EBSBlockDeviceType()
-    ebs_volume.size = disk_size
-    bdm = BlockDeviceMapping()
-    bdm[disk_name] = ebs_volume
-
-    # get an ec2 ami image object with our choosen ami
-    image = connection.get_all_images(ami)[0]
-    # start a new instance
-    reservation = image.run(1, 1,
-                            key_name=key_pair,
-                            security_groups=security_groups,
-                            block_device_map=bdm,
-                            instance_type=instance_type)
-
-    # and get our instance_id
-    instance = reservation.instances[0]
-
-    #  and loop and wait until ssh is available
-    while instance.state == u'pending':
-        if log:
-            log_yellow("Instance state: %s" % instance.state)
-        sleep(10)
-        instance.update()
-    if log:
-        log_green("Instance state: %s" % instance.state)
-    if wait_for_ssh_available:
-        wait_for_ssh(instance.public_dns_name)
-
-    # update the EBS volumes to be deleted on instance termination
-    if delete_on_termination:
-        for dev, bd in instance.block_device_mapping.items():
-            instance.modify_attribute('BlockDeviceMapping',
-                                      ["%s=%d" % (dev, 1)])
-
-    # add a tag to our instance
-    connection.create_tags([instance.id], tags)
-
-    if log:
-        log_green("Public dns: %s" % instance.public_dns_name)
-
-    # returns our new instance
-    return instance
 
 
 def destroy_ebs_volume(connection, region, volume_id, log=False):

--- a/bookshelf/api_v2/ec2.py
+++ b/bookshelf/api_v2/ec2.py
@@ -1,6 +1,5 @@
 # vim: ai ts=4 sts=4 et sw=4 ft=python fdm=indent et
 
-import boto.ec2
 
 from boto.ec2.blockdevicemapping import BlockDeviceMapping, EBSBlockDeviceType
 from fabric.api import env
@@ -8,17 +7,6 @@ from time import sleep
 from bookshelf.api_v2.time_helpers import sleep_for_one_minute
 from bookshelf.api_v2.logging_helpers import log_green, log_yellow, log_red
 from bookshelf.api_v2.cloud import wait_for_ssh
-
-
-def connect_to_ec2(region, access_key_id, secret_access_key):
-    """ returns a connection object to AWS EC2  """
-    conn = boto.ec2.connect_to_region(region,
-                                      aws_access_key_id=access_key_id,
-                                      aws_secret_access_key=secret_access_key)
-    if conn:
-        return conn
-    else:
-        return False
 
 
 def create_ami(connection,

--- a/bookshelf/api_v3/cloud_instance.py
+++ b/bookshelf/api_v3/cloud_instance.py
@@ -75,8 +75,9 @@ class ICloudInstance(Interface):
 
     region = Attribute("""The region the instance is in.""")
 
-    name = Attribute(
-        """The human readable name of the instance.""")
+    image_basename = Attribute(
+        "The basename for the image. The final name will look like"
+        "image_basename-YYYYMMDDHHMMSS")
 
     def create_image(image_name):
         """

--- a/bookshelf/api_v3/cloud_instance.py
+++ b/bookshelf/api_v3/cloud_instance.py
@@ -73,6 +73,8 @@ class ICloudInstance(Interface):
         """The distribution on the instance. Should be one of the above """
         """Distributions.""")
 
+    region = Attribute("""The region the instance is in.""")
+
     name = Attribute(
         """The human readable name of the instance.""")
 

--- a/bookshelf/api_v3/cloud_instance.py
+++ b/bookshelf/api_v3/cloud_instance.py
@@ -56,14 +56,18 @@ class ICloudInstance(Interface):
     """
     Interface for interacting with a single cloud interface.
     """
-    public_dns_name = Attribute(
-        """A name that will resolve to the instance.""")
-
     username = Attribute(
         """The username to use to log into the instance.""")
 
     key_filename = Attribute(
         """The filename of the private key to use to log into the instance.""")
+
+    distro = Attribute(
+        """The distribution used to create the base image. Must be one of the
+        enumerated values in Distribution.""")
+
+    ip_address = Attribute(
+        """Externally accessable IP address for the instance""")
 
     def create_image(image_name):
         """

--- a/bookshelf/api_v3/cloud_instance.py
+++ b/bookshelf/api_v3/cloud_instance.py
@@ -1,39 +1,102 @@
-from zope.interface import Interface
+from zope.interface import Interface, Attribute
+from enum import Enum
+
+
+class Distribution(Enum):
+    """
+    Enumeration of distributions supported by the bookshelf v3 api.
+
+    :ivar CENTOS7: constant for CentOS 7.
+    :ivar UBUNTU1404: constante for Ubuntu LTS 14.04.
+    """
+    CENTOS7 = u"centos7"
+    UBUNTU1404 = u"ubuntu1404"
+
+
+class ICloudInstanceFactory(Interface):
+    """
+    Interface for an object that can create cloud instances either from some
+    existing serialized state, or create a new cloud instance from a
+    configuration.
+    """
+
+    def create_from_config(config, distro):
+        """
+        Creates a new instance of the specified distro from the given
+        configuration.
+
+        :param dict config: An implementation-specific configuration
+            dictionary. This is most likely something read in from a
+            configuration language and passed directly to this layer.
+        :param Distribution distro: The distribution to spin the instance up
+            as.
+
+        :return: An :class:`ICloudInstance` provider for a newly created
+            instance with type distro.
+        """
+        pass
+
+    def create_from_saved_state(config, saved_state):
+        """
+        Re-create or connect to an existing cloud instance as specified in some
+        saved state and configuration.
+
+        :param config: An opaque dict of configuration that might be specific
+            to a given implementation
+        :param saved_state: The serialization state of an instance created by
+            serializing a previously
+
+        :return: An :class:`ICloudInstance` provider loaded from the
+            saved_state.
+        """
+        pass
 
 
 class ICloudInstance(Interface):
-    # @classmethod
-    # def create_from_config(config, region, distro):
-    #     """
-    #     Uses config to create a new ICloudInstance. Creates the VM as
-    #     well***
-    #     """
-    # @classmethod
-    # def create_from_state():
-    #     pass
+    """
+    Interface for interacting with a single cloud interface.
+    """
+    public_dns_name = Attribute(
+        """A name that will resolve to the instance.""")
 
-    def create_image(name, description):
-        """Creates an image and leaves it in an up state
+    username = Attribute(
+        """The username to use to log into the instance.""")
+
+    key_filename = Attribute(
+        """The filename of the private key to use to log into the instance.""")
+
+    def create_image(image_name):
+        """
+        Creates an image from the boot disk of the instance, and leaves the
+        instance in an up (booted) state.
+
+        :param unicode image_name: The name of the image to create.
         """
 
     def destroy():
         """
-        Destroys an existing image
+        Downs and Destroys the instance.
         """
 
     def down():
         """
-        Stops a running image. Throws an exception if the image is not
-        running
+        Stops a running instance. Throws an exception if the instance is not
+        running. Note that this must be done in a way where the instance can be
+        started again.
         """
     def up():
         """
-        starts an existing image. Throws an exception if the image is
+        Starts an existing instance. Throws an exception if the instance is
         already running.
         """
 
     def serialize_to_state():
         """
-        Saves information about this image to a json file that will be used
-        on susequent fab runs.
+        Serializes this instance to a dictionary that can be passed to
+        ``ICloudInstanceFactory.create_from_saved_state`` in order to
+        re-create an :class:`ICloudInstance` that references the same
+        underlying instance.
+
+        :returns dict: A simple dictionary of plain old data that can be
+            serialized using the JSON library.
         """

--- a/bookshelf/api_v3/cloud_instance.py
+++ b/bookshelf/api_v3/cloud_instance.py
@@ -20,7 +20,7 @@ class ICloudInstanceFactory(Interface):
     configuration.
     """
 
-    def create_from_config(config, distro):
+    def create_from_config(config, distro, region):
         """
         Creates a new instance of the specified distro from the given
         configuration.
@@ -30,6 +30,7 @@ class ICloudInstanceFactory(Interface):
             configuration language and passed directly to this layer.
         :param Distribution distro: The distribution to spin the instance up
             as.
+        :param unicode region: The region to spin the instance up within.
 
         :return: An :class:`ICloudInstance` provider for a newly created
             instance with type distro.

--- a/bookshelf/api_v3/cloud_instance.py
+++ b/bookshelf/api_v3/cloud_instance.py
@@ -84,13 +84,8 @@ class ICloudInstance(Interface):
         running. Note that this must be done in a way where the instance can be
         started again.
         """
-    def up():
-        """
-        Starts an existing instance. Throws an exception if the instance is
-        already running.
-        """
 
-    def serialize_to_state():
+    def get_state():
         """
         Serializes this instance to a dictionary that can be passed to
         ``ICloudInstanceFactory.create_from_saved_state`` in order to

--- a/bookshelf/api_v3/cloud_instance.py
+++ b/bookshelf/api_v3/cloud_instance.py
@@ -1,5 +1,5 @@
 from zope.interface import Interface, Attribute
-from enum import Enum
+from flufl.enum import Enum
 
 
 class Distribution(Enum):
@@ -66,12 +66,24 @@ class ICloudInstance(Interface):
     key_filename = Attribute(
         """The filename of the private key to use to log into the instance.""")
 
+    cloud_type = Attribute(
+        """The name of the cloud this instance comes from.""")
+
+    distro = Attribute(
+        """The distribution on the instance. Should be one of the above """
+        """Distributions.""")
+
+    name = Attribute(
+        """The human readable name of the instance.""")
+
     def create_image(image_name):
         """
         Creates an image from the boot disk of the instance, and leaves the
         instance in an up (booted) state.
 
         :param unicode image_name: The name of the image to create.
+
+        :returns: The unique identifier of the image.
         """
 
     def destroy():

--- a/bookshelf/api_v3/cloud_instance.py
+++ b/bookshelf/api_v3/cloud_instance.py
@@ -1,0 +1,40 @@
+from zope.interface import Interface
+
+STATE_FILE_NAME = '.state.json'
+
+
+class ICloudInstance(Interface):
+    # @classmethod
+    # def create_from_config(config, region, distro):
+    #     """
+    #     Uses config to create a new ICloudInstance. Creates the VM as
+    #     well***
+    #     """
+    # @classmethod
+    # def create_from_state():
+    #     pass
+
+    def create_image(name, description):
+        """Creates an image and leaves it in an up state
+        """
+    def destroy():
+        """
+        Destroys an existing image
+        """
+
+    def down():
+        """
+        Stops a running image. Throws an exception if the image is not
+        running
+        """
+    def up():
+        """
+        starts an existing image. Throws an exception if the image is
+        already running.
+        """
+
+    def serialize_to_state():
+        """
+        Saves information about this image to a json file that will be used
+        on susequent fab runs.
+        """

--- a/bookshelf/api_v3/cloud_instance.py
+++ b/bookshelf/api_v3/cloud_instance.py
@@ -15,9 +15,9 @@ class Distribution(Enum):
 
 class ICloudInstanceFactory(Interface):
     """
-    Interface for an object that can create cloud instances either from some
-    existing serialized state, or create a new cloud instance from a
-    configuration.
+    Interface for an object that can create cloud instances either
+    from some existing serialized/saved state, or create a new cloud
+    instance from a configuration.
     """
 
     def create_from_config(config, distro, region):
@@ -42,10 +42,12 @@ class ICloudInstanceFactory(Interface):
         Re-create or connect to an existing cloud instance as specified in some
         saved state and configuration.
 
-        :param config: An opaque dict of configuration that might be specific
-            to a given implementation
-        :param saved_state: The serialization state of an instance created by
-            serializing a previously
+        :param config: An opaque dict of configuration that might be
+            specific to a given implementation
+        :param saved_state: The serialized state of an instance that
+            has most likely been loaded from disk (e.g. a json file).
+            This saved state will be used to reconnect to an existing
+            instance.
 
         :return: An :class:`ICloudInstance` provider loaded from the
             saved_state.
@@ -87,6 +89,18 @@ class ICloudInstance(Interface):
         :param unicode image_name: The name of the image to create.
 
         :returns: The unique identifier of the image.
+        """
+
+    def delete_image(image_name):
+        """
+        Hack: This should not go in the instance as it's a general cloud
+        operation. If more general cloud operaions are needed, they
+        should be broken out of the Instance object into their own
+        thing.
+
+        Deletes an image from the cloud
+
+        :param unicode image_name: the name of the image to delete
         """
 
     def destroy():

--- a/bookshelf/api_v3/cloud_instance.py
+++ b/bookshelf/api_v3/cloud_instance.py
@@ -1,7 +1,5 @@
 from zope.interface import Interface
 
-STATE_FILE_NAME = '.state.json'
-
 
 class ICloudInstance(Interface):
     # @classmethod
@@ -17,6 +15,7 @@ class ICloudInstance(Interface):
     def create_image(name, description):
         """Creates an image and leaves it in an up state
         """
+
     def destroy():
         """
         Destroys an existing image

--- a/bookshelf/api_v3/ec2.py
+++ b/bookshelf/api_v3/ec2.py
@@ -133,7 +133,8 @@ def _create_server_ec2(connection,
                                       ["%s=%d" % (dev, 1)])
 
     # add a tag to our instance
-    connection.create_tags([instance.id], tags)
+    if tags:
+        connection.create_tags([instance.id], tags)
 
     if log:
         log_green("Public dns: %s" % instance.public_dns_name)

--- a/bookshelf/api_v3/ec2.py
+++ b/bookshelf/api_v3/ec2.py
@@ -47,6 +47,7 @@ class EC2Configuration(PClass):
     instance_name = field(type=unicode, mandatory=True, factory=unicode)
     tags = field(type=PMap, mandatory=True, factory=_parse_unicode_pmap)
     image_description = field(type=unicode, mandatory=True, factory=unicode)
+    image_basename = field(type=unicode, mandatory=True, factory=unicode)
     ami = field(type=unicode, mandatory=True, factory=unicode)
     key_filename = field(type=unicode, mandatory=True, factory=unicode)
     key_pair = field(type=unicode, mandatory=True, factory=unicode)
@@ -167,8 +168,8 @@ class EC2():
         return self.instance.ip_address
 
     @property
-    def name(self):
-        return self.config.instance_name
+    def image_basename(self):
+        return self.config.image_basename
 
     @property
     def username(self):

--- a/bookshelf/api_v3/ec2.py
+++ b/bookshelf/api_v3/ec2.py
@@ -198,7 +198,7 @@ class EC2():
             region=region,
             disk_name=parsed_config.disk_name,
             disk_size=parsed_config.disk_size,
-            ami=parsed_config.config.ami,
+            ami=parsed_config.ami,
             key_pair=parsed_config.key_pair,
             instance_type=parsed_config.instance_type,
             tags=parsed_config.tags,

--- a/bookshelf/api_v3/ec2.py
+++ b/bookshelf/api_v3/ec2.py
@@ -1,0 +1,336 @@
+
+from time import sleep
+
+import boto.ec2
+from boto.ec2.blockdevicemapping import BlockDeviceMapping, EBSBlockDeviceType
+from pyrsistent import PClass, field, pmap, PMap, pvector, PVector
+from zope.interface import implementer, provider
+
+from bookshelf.api_v3.cloud_instance import (
+    ICloudInstance, ICloudInstanceFactory, Distribution
+)
+
+from bookshelf.api_v2.logging_helpers import log_green, log_yellow, log_red
+from bookshelf.api_v2.cloud import wait_for_ssh
+
+
+class EC2State(PClass):
+    instance_id = field(type=unicode, mandatory=True, factory=unicode)
+    region = field(type=unicode, mandatory=True, factory=unicode)
+    distro = field(mandatory=True, factory=Distribution,
+                   serializer=lambda _, x: x.value)
+
+
+class EC2Credentials(PClass):
+    """
+    The credentials needed to authenticate with EC2.
+    """
+    access_key_id = field(type=unicode, mandatory=True, factory=unicode)
+    secret_access_key = field(type=unicode, mandatory=True, factory=unicode)
+
+
+def _parse_unicode_pmap(d):
+    return pmap({unicode(k): unicode(v)
+                 for k, v in d.iteritems()})
+
+
+def _parse_unicode_pvector(l):
+    return pvector([unicode(x) for x in l])
+
+
+class EC2DistroConfig(PClass):
+    """
+    Distribution-specific configuration values.
+    """
+    username = field(type=unicode, mandatory=True, factory=unicode)
+    instance_name = field(type=unicode, mandatory=True, factory=unicode)
+    amis = field(type=PMap, mandatory=True, factory=_parse_unicode_pmap)
+    tags = field(type=PMap, mandatory=True, factory=_parse_unicode_pmap)
+    image_description = field(type=unicode, mandatory=True, factory=unicode)
+
+
+def _parse_distro_info(config):
+    result = pmap()
+    for key, value in config.iteritems():
+        distro = Distribution(key)
+        result = result.set(distro, EC2DistroConfig.create(value))
+    return result
+
+
+class EC2Configuration(PClass):
+    """
+    The configuration needed to authenticate with EC2.
+    """
+    credentials = field(type=EC2Credentials, mandatory=True)
+    distros = field(mandatory=True, factory=_parse_distro_info)
+    key_filename = field(type=unicode, mandatory=True, factory=unicode)
+    key_pair = field(type=unicode, mandatory=True, factory=unicode)
+    instance_type = field(type=unicode, mandatory=True, factory=unicode)
+    disk_name = field(type=unicode, mandatory=True, factory=unicode)
+    disk_size = field(type=int, mandatory=True, factory=int)
+    security_groups = field(type=PVector, mandatory=True,
+                            factory=_parse_unicode_pvector)
+
+
+def _connect_to_ec2(region, credentials):
+    """
+    :param region: The region of AWS to connect to.
+    :param EC2Credentials credentials: The credentials to use to authenticate
+        with EC2.
+
+    :return: a connection object to AWS EC2
+    """
+    conn = boto.ec2.connect_to_region(
+        region,
+        aws_access_key_id=credentials.access_key_id,
+        aws_secret_access_key=credentials.secret_access_key
+    )
+    if conn:
+        return conn
+    else:
+        log_red('Failure to authenticate to EC2.')
+        return False
+
+
+def _create_server_ec2(connection,
+                       region,
+                       disk_name,
+                       disk_size,
+                       ami,
+                       key_pair,
+                       instance_type,
+                       tags={},
+                       security_groups=None,
+                       delete_on_termination=True,
+                       log=False,
+                       wait_for_ssh_available=True):
+    """
+    Creates EC2 Instance
+    """
+
+    if log:
+        log_green("Started...")
+        log_yellow("...Creating EC2 instance...")
+
+    ebs_volume = EBSBlockDeviceType()
+    ebs_volume.size = disk_size
+    bdm = BlockDeviceMapping()
+    bdm[disk_name] = ebs_volume
+
+    # get an ec2 ami image object with our choosen ami
+    image = connection.get_all_images(ami)[0]
+    # start a new instance
+    reservation = image.run(1, 1,
+                            key_name=key_pair,
+                            security_groups=security_groups,
+                            block_device_map=bdm,
+                            instance_type=instance_type)
+
+    # and get our instance_id
+    instance = reservation.instances[0]
+
+    #  and loop and wait until ssh is available
+    while instance.state == u'pending':
+        if log:
+            log_yellow("Instance state: %s" % instance.state)
+        sleep(10)
+        instance.update()
+    if log:
+        log_green("Instance state: %s" % instance.state)
+    if wait_for_ssh_available:
+        wait_for_ssh(instance.public_dns_name)
+
+    # update the EBS volumes to be deleted on instance termination
+    if delete_on_termination:
+        for dev, bd in instance.block_device_mapping.items():
+            instance.modify_attribute('BlockDeviceMapping',
+                                      ["%s=%d" % (dev, 1)])
+
+    # add a tag to our instance
+    connection.create_tags([instance.id], tags)
+
+    if log:
+        log_green("Public dns: %s" % instance.public_dns_name)
+
+    # returns our new instance
+    return instance
+
+
+@implementer(ICloudInstance)
+@provider(ICloudInstanceFactory)
+class EC2():
+    """
+    Class representing an EC2 instance, that provides methods for interacting
+    with the instance.
+
+    :ivar connection: A boto connection object to interact with ec2.
+    :ivar instance: A boto instance object.
+    :ivar config: An EC2Configuration describing the configuration for this EC2
+        instance.
+    :ivar state: An EC2State describing this EC2 instance.
+    """
+    def __init__(self, instance, connection, config, state):
+        self.connection = connection
+        self.instance = instance
+        self.config = config
+        self.state = state
+
+    cloud_type = u'ec2'
+
+    @property
+    def _distro_config(self):
+        return self.config.distros[self.state.distro]
+
+    @property
+    def public_dns_name(self):
+        return self.instance.public_dns_name
+
+    @property
+    def name(self):
+        return self._distro_config.instance_name
+
+    @property
+    def username(self):
+        return self._distro_config.username
+
+    @property
+    def key_filename(self):
+        return self.config.key_filename
+
+    @property
+    def distro(self):
+        return self.state.distro
+
+    @classmethod
+    def create_from_config(cls, config, distro, region):
+        parsed_config = EC2Configuration.create(config)
+        connection = _connect_to_ec2(
+            region=region,
+            credentials=parsed_config.credentials
+        )
+        distro_config = parsed_config.distros[distro]
+        instance = _create_server_ec2(
+            connection=connection,
+            region=region,
+            disk_name=parsed_config.disk_name,
+            disk_size=parsed_config.disk_size,
+            ami=distro_config.amis[region],
+            key_pair=parsed_config.key_pair,
+            instance_type=parsed_config.instance_type,
+            tags=distro_config.tags,
+            security_groups=parsed_config.security_groups,
+            delete_on_termination=True,
+            log=False,
+            wait_for_ssh_available=True
+        )
+        state = EC2State(
+            instance_id=instance.id,
+            region=region,
+            distro=distro,
+        )
+
+        return cls(
+            connection=connection,
+            instance=instance,
+            config=parsed_config,
+            state=state
+        )
+
+    @classmethod
+    def create_from_saved_state(cls, config, saved_state):
+        parsed_config = EC2Configuration.create(config)
+        state = EC2State.create(saved_state)
+        connection = _connect_to_ec2(
+            region=state.region,
+            credentials=parsed_config.credentials
+        )
+
+        timeout = 600
+        instance = connection.start_instances(
+            instance_ids=state.instance_id)[0]
+        instance.update()
+        while instance.state != "running" and timeout > 1:
+            log_yellow("Instance state: %s" % instance.state)
+            sleep(10)
+            timeout = timeout - 10
+            instance.update()
+
+        # and make sure we don't return until the instance is fully up
+        wait_for_ssh(instance.ip_address)
+        return cls(
+            connection=connection,
+            instance=instance,
+            config=parsed_config,
+            state=state
+        )
+
+    def create_image(self, image_name):
+        ami = self.connection.create_image(
+            self.state.instance_id,
+            image_name,
+            description=self._distro_config.image_description,
+        )
+
+        image_status = self.connection.get_image(ami)
+        while (image_status.state != "available" and
+               image_status.state != "failed"):
+            log_yellow('creating ami...')
+            sleep(60)
+            image_status = self.connection.get_image(ami)
+
+        if image_status.state == "available":
+            log_green("ami %s %s" % (ami, image_status))
+            return(ami)
+        else:
+            log_red("ami %s %s" % (ami, image_status))
+            return False
+
+    def _ebs_volume_exists(self, volume_id):
+        """ finds out if a ebs volume exists """
+        for vol in self.connection.get_all_volumes():
+            if vol.id == volume_id:
+                return True
+        return False
+
+    def _destroy_ebs_volume(self, volume_id):
+        """ destroys an ebs volume """
+
+        if self._ebs_volume_exists(volume_id):
+            log_yellow('destroying EBS volume ...')
+            try:
+                self.connection.delete_volume(volume_id)
+            except:
+                # our EBS volume may be gone, but AWS info tables are stale
+                # wait a bit and ask again
+                sleep(5)
+                if not self._ebs_volume_exists(volume_id):
+                    pass
+                else:
+                    raise("Couldn't delete EBS volume")
+
+    def destroy(self):
+        self.down()
+        volumes = self.connection.get_all_volumes(
+            filters={'attachment.instance-id': self.state.instance_id}
+        )
+        instance = self.connection.terminate_instances(
+            instance_ids=[self.state.instance_id])[0]
+        log_yellow('destroying instance ...')
+        while instance.state != "terminated":
+            log_yellow("Instance state: %s" % instance.state)
+            sleep(10)
+            instance.update()
+        for volume in volumes:
+            self._destroy_ebs_volume(volume.id)
+
+    def down(self):
+        instance = self.connection.stop_instances(
+            instance_ids=self.state.instance_id)[0]
+        while instance.state != "stopped":
+            log_yellow("Instance state: %s" % instance.state)
+            sleep(10)
+            instance.update()
+        log_green('Instance state: %s' % instance.state)
+
+    def get_state(self):
+        return self.state.serialize()

--- a/bookshelf/api_v3/gce.py
+++ b/bookshelf/api_v3/gce.py
@@ -23,13 +23,13 @@ class GCE(object):
 
     cloud = 'gce'
 
-    def __init__(self, config, distro):
+    def __init__(self, config, distro, region):
 
         self.distro = distro
 
         # config
         self.project = config['project']
-        self.zone = config['zone']
+        self.zone = region
         self.public_key_filename = config['public_key_filename']
         self.machine_type = config['machine_type']
         self.username = config['username']
@@ -49,18 +49,17 @@ class GCE(object):
         return socket.gethostbyaddr(self.ip_address)[0]
 
     @classmethod
-    def create_from_config(cls, config, distro):
-        gce_instance = GCE(config, distro)
+    def create_from_config(cls, config, region, distro):
+        gce_instance = GCE(config, distro, region)
         # we have no state so create a new instance
         gce_instance.instance_name = u"slave-image-prep-" + unicode(uuid.uuid4())
         gce_instance._create_server()
         return gce_instance
 
-
     @classmethod
     def create_from_saved_state(cls, config, saved_state):
         # state has to include credentials, could also take config
-        gce_instance = GCE(config, saved_state['distro'])
+        gce_instance = GCE(config, saved_state['distro'], saved_state['zone'])
         gce_instance.instance_name = saved_state['instance_name']
         gce_instance.distro = saved_state['distro']
         gce_instance.ensure_instance_running(saved_state['instance_name'])
@@ -379,6 +378,7 @@ class GCE(object):
             'ip_address': self.ip_address,
             'instance_name': self.instance_name,
             'distro': self.distro,
+            'zone': self.zone
         }
 
         data['distribution'] = linux_distribution(self.username, self.ip_address)

--- a/bookshelf/api_v3/gce.py
+++ b/bookshelf/api_v3/gce.py
@@ -166,7 +166,7 @@ class GCE(object):
             self._compute.images().insert(
                 project=self.project, body=body).execute()
         )
-        return self.description
+        return image_name
 
 
     def down(self):

--- a/bookshelf/api_v3/gce.py
+++ b/bookshelf/api_v3/gce.py
@@ -68,7 +68,7 @@ class GCE(object):
         # if we've restarted a terminated server, the ip address
         # might have changed from our saved state, get the
         # networking info and resave the state
-        gce_instance._set_instance_networking(gce_instance.instance_name)
+        gce_instance._set_instance_networking()
         return gce_instance
 
     def ensure_instance_running(self, instance_name):
@@ -168,7 +168,7 @@ class GCE(object):
             self._compute.images().insert(
                 project=self.project, body=body).execute()
         )
-        return self.description
+        return image_name
 
 
     def down(self):
@@ -384,3 +384,4 @@ class GCE(object):
 
         data['distribution'] = linux_distribution(self.username, self.ip_address)
         data['os_release'] = os_release(self.username, self.ip_address)
+        return data

--- a/bookshelf/api_v3/gce.py
+++ b/bookshelf/api_v3/gce.py
@@ -239,7 +239,7 @@ class GCEInstance(object):
                 project=self.project, image=image_name).execute()
         )
         log_yellow("Delete image returned status {}".format(
-            result['statusMessage'])
+            result['status'])
         )
 
     def down(self):

--- a/bookshelf/api_v3/gce.py
+++ b/bookshelf/api_v3/gce.py
@@ -1,8 +1,6 @@
 import socket
-import json
 from time import time, sleep
 import uuid
-from pprint import pprint
 
 
 from oauth2client.client import GoogleCredentials
@@ -14,12 +12,13 @@ from bookshelf.api_v1 import (
     wait_for_ssh, linux_distribution, os_release
 )
 
-from zope.interface import implementer
+from zope.interface import implementer, provider
 
-from cloud_instance import ICloudInstance
+from cloud_instance import ICloudInstance, ICloudInstanceFactory
 
 
 @implementer(ICloudInstance)
+@provider(ICloudInstanceFactory)
 class GCE(object):
 
     cloud = 'gce'

--- a/bookshelf/api_v3/gce.py
+++ b/bookshelf/api_v3/gce.py
@@ -1,0 +1,412 @@
+import socket
+import json
+from time import time, sleep
+import uuid
+from pprint import pprint
+
+
+from oauth2client.client import GoogleCredentials
+from googleapiclient import discovery
+from googleapiclient.errors import HttpError
+
+from bookshelf.api_v2.logging_helpers import log_green, log_yellow, log_red
+from bookshelf.api_v1 import (
+    wait_for_ssh, linux_distribution, os_release
+)
+
+from zope.interface import implementer
+
+from cloud_instance import ICloudInstance, STATE_FILE_NAME
+
+
+
+
+# create_from_config
+# create_from_state
+#
+# create_image(name, description)
+# -- leaves image in an up state
+# destroy
+# down
+# up
+# (getters for key_filename, username, public_dns_name, distribution, region)
+# serialize_to_state
+# -- return errors if downing a downed instance or upping an instance that is up
+
+@implementer(ICloudInstance)
+class GCE(object):
+
+    def __init__(self, config, distro):
+        self.distro = distro
+
+        # config
+        self.project = config['project']
+        self.zone = config['zone']
+        self.public_key_filename = config['public_key_filename']
+        self.private_key_filename = config['private_key_filename']
+        self.machine_type = config['machine_type']
+        self.username = config['username']
+
+        # distro
+        self.base_image_prefix = config[distro]['base_image_prefix']
+        self.base_image_project = config[distro]['base_image_project']
+        self.description = config[distro]['description']
+
+        # state (set when creating from saved state)
+        self.ip_address = None
+
+        self._compute = self._get_gce_compute()
+
+    @property
+    def public_dns_name(self):
+        return socket.gethostbyaddr(self.ip_address)[0]
+
+    @classmethod
+    def create_from_config(cls, config, distro):
+        gce_instance = GCE(config, distro)
+        # we have no state so create a new instance
+        gce_instance.instance_name = u"slave-image-prep-" + unicode(uuid.uuid4())
+        gce_instance._create_server()
+        return gce_instance
+
+
+    @classmethod
+    def create_from_saved_state(cls, config, saved_state):
+        # state has to include credentials, could also take config
+        gce_instance = GCE(config, saved_state['distro'])
+        gce_instance.instance_name = saved_state['instance_name']
+        gce_instance.distro = saved_state['distro']
+        gce_instance.ensure_instance_running(saved_state['instance_name'])
+        # if we've restarted a terminated server, the ip address
+        # might have changed from our saved state, get the
+        # networking info and resave the state
+        instance_ip = gce_instance._get_instance_networking(
+            gce_instance.instance_name)
+        gce_instance._save_state_locally(
+            instance_name=gce_instance.instance_name,
+            ip_address=instance_ip
+        )
+
+        return gce_instance
+
+    def ensure_instance_running(self, instance_name):
+        try:
+            instance_info = self._compute.instances().get(
+                project=self.project, zone=self.zone, instance=instance_name
+            ).execute()
+            if instance_info['status'] == 'RUNNING':
+                pass
+            elif instance_info['status'] == 'TERMINATED':
+                self._start_terminated_server(instance_name)
+            else:
+                msg = ("Instance {} is in state {}, "
+                       "please start it from the console").format(
+                           instance_name, instance_info['status'])
+                raise Exception(msg)
+            # if we've started a terminated server, re-save
+            # the networking info, if we have
+        except HttpError as e:
+            if e.resp.status == 404:
+                log_red("Instance {} does not exist".format(
+                    instance_name)
+                )
+                log_yellow("you might need to remove state file {}".format(
+                    STATE_FILE_NAME)
+                )
+            else:
+                log_red("Unknown error querying for instance {}".format(
+                    instance_name)
+                )
+            raise e
+
+
+    def _start_terminated_server(self, instance_name):
+        log_yellow("starting terminated instance {}".format(instance_name))
+        operation = self._compute.instances().start(
+            project=self.project,
+            zone=self.zone,
+            instance=instance_name
+        ).execute()
+        self._wait_until_done(operation)
+
+
+    def _get_instance_networking(self, instance_name):
+        instance_data = self._compute.instances().get(
+            project=self.project, zone=self.zone, instance=instance_name
+        ).execute()
+
+        self.instance_ip = (
+            instance_data['networkInterfaces'][0]['accessConfigs'][0]['natIP']
+        )
+        wait_for_ssh(self.instance_ip)
+
+        log_green('Server has IP address {0}.'.format(self.instance_ip))
+        return self.instance_ip
+
+
+    def _create_server(self):
+
+        log_green("Started...")
+        log_yellow("...Creating GCE instance...")
+        latest_image = self._get_latest_image(
+            self.base_image_project, self.base_image_prefix)
+
+        self.startup_instance(instance_name,
+                              latest_image['selfLink'],
+                              disk_name=None)
+
+        instance_ip = self._get_instance_networking(instance_name)
+        self._save_state_locally(instance_name=instance_name,
+                                ip_address=instance_ip)
+
+
+    def create_image(self, image_name):
+        """
+        Shuts down the instance and creates and image from the disk.
+        Assumes that the disk name is the same as the instance_name (this is the
+        default behavior for boot disks on GCE).
+        """
+
+        disk_name = self.instance_name
+        try:
+            self.destroy()
+        except HttpError as e:
+            if e.resp.status == 404:
+                log_yellow(
+                    "the instance {} is already down".format(
+                        self.instance_name)
+                )
+            else:
+                raise e
+
+        body = {
+            "rawDisk": {},
+            "name": image_name,
+            "sourceDisk": "projects/{}/zones/{}/disks/{}".format(
+                self.project, self.zone, disk_name
+            ),
+            "description": self.description
+        }
+        self._wait_until_done(
+            self._compute.images().insert(
+                project=self.project, body=body).execute()
+        )
+        return self.description
+
+
+    def down(self):
+        log_yellow("downing server: {}".format(self.instance_name))
+        self._wait_until_done(self._compute.instances().stop(
+            project=self.project,
+            zone=self.zone,
+            instance=self.instance_name
+        ).execute())
+
+    def destroy(self):
+        log_yellow("downing server: {}".format(self.instance_name))
+        self._wait_until_done(self._compute.instances().delete(
+            project=self.project,
+            zone=self.zone,
+            instance=self.instance_name
+        ).execute())
+
+
+    def _get_instance_config(self,
+                            instance_name,
+                            image,
+                            disk_name=None):
+        public_key = open(self.public_key_filename, 'r').read()
+        if disk_name:
+            disk_config = {
+                "type": "PERSISTENT",
+                "boot": True,
+                "mode": "READ_WRITE",
+                "autoDelete": False,
+                "source": "projects/{}/zones/{}/disks/{}".format(
+                    self.project, self.zone, disk_name)
+            }
+        else:
+            disk_config = {
+                "type": "PERSISTENT",
+                "boot": True,
+                "mode": "READ_WRITE",
+                "autoDelete": False,
+                "initializeParams": {
+                    "sourceImage": image,
+                    "diskType": (
+                        "projects/{}/zones/{}/diskTypes/pd-standard".format(
+                            self.project, self.zone)
+                    ),
+                    "diskSizeGb": "10"
+                }
+            }
+        gce_slave_instance_config = {
+            'name': instance_name,
+            'machineType': (
+                "projects/{}/zones/{}/machineTypes/{}".format(
+                    self.project, self.zone, self.machine_type)
+                ),
+            'disks': [disk_config],
+            "networkInterfaces": [
+                {
+                    "network": (
+                        "projects/%s/global/networks/default" % self.project
+                    ),
+                    "accessConfigs": [
+                        {
+                            "name": "External NAT",
+                            "type": "ONE_TO_ONE_NAT"
+                        }
+                    ]
+                }
+            ],
+            "metadata": {
+                "items": [
+                    {
+                        "key": "sshKeys",
+                        "value": "{}:{}".format(self.username, public_key)
+                    }
+                ]
+            },
+            'description':
+                'created by: https://github.com/ClusterHQ/CI-slave-images',
+            "serviceAccounts": [
+                {
+                    "email": "default",
+                    "scopes": [
+                        "https://www.googleapis.com/auth/compute",
+                        "https://www.googleapis.com/auth/cloud.useraccounts.readonly",
+                        "https://www.googleapis.com/auth/devstorage.read_only",
+                        "https://www.googleapis.com/auth/logging.write",
+                        "https://www.googleapis.com/auth/monitoring.write"
+                    ]
+                }
+            ]
+        }
+        return gce_slave_instance_config
+
+
+    def startup_instance(self, instance_name, image, disk_name=None):
+        """
+        For now, jclouds is broken for GCE and we will have static slaves
+        in Jenkins.  Use this to boot them.
+        """
+        log_green("Started...")
+        log_yellow("...Starting GCE Jenkins Slave Instance...")
+        instance_config = self._get_instance_config(
+            instance_name, image, disk_name
+        )
+        pprint(instance_config)
+        operation = self._compute.instances().insert(
+            project=self.project,
+            zone=self.zone,
+            body=instance_config
+        ).execute()
+        result = self._wait_until_done(operation)
+        if not result:
+            raise RuntimeError("Creation of VM timed out or returned no result")
+        log_green("Instance has booted")
+
+
+    def _get_gce_compute(self):
+        credentials = GoogleCredentials.get_application_default()
+        compute = discovery.build('compute', 'v1', credentials=credentials)
+        return compute
+
+
+    def _wait_until_done(self, operation):
+        """
+        Perform a GCE operation, blocking until the operation completes.
+
+        This function will then poll the operation until it reaches state
+        'DONE' or times out, and then returns the final operation resource
+        dict.
+
+        :param operation: A dict representing a pending GCE operation resource.
+
+        :returns dict: A dict representing the concluded GCE operation
+            resource.
+        """
+        operation_name = operation['name']
+        if 'zone' in operation:
+            zone_url_parts = operation['zone'].split('/')
+            project = zone_url_parts[-3]
+            zone = zone_url_parts[-1]
+
+            def get_zone_operation():
+                return self._compute.zoneOperations().get(
+                    project=project,
+                    zone=zone,
+                    operation=operation_name
+                )
+            update = get_zone_operation
+        else:
+            project = operation['selfLink'].split('/')[-4]
+
+            def get_global_operation():
+                return self._compute.globalOperations().get(
+                    project=project,
+                    operation=operation_name
+                )
+            update = get_global_operation
+        done = False
+        latest_operation = None
+        start = time()
+        timeout = 5*60  # seconds
+        while not done:
+            latest_operation = update().execute()
+            log_yellow("waiting for operation")
+            if (latest_operation['status'] == 'DONE' or
+                    time() - start > timeout):
+                done = True
+            else:
+                sleep(10)
+                print "waiting for operation"
+        return latest_operation
+
+
+    def _get_latest_image(self, base_image_project, image_name_prefix):
+        """ Gets the latest image for a distribution on gce.
+
+        The best way to get a list of possible image_name_prefix values is to look
+        at the output from ``gcloud compute images list``
+
+        If you don't have the gcloud executable installed, it can be pip installed:
+        ``pip install gcloud``
+
+        project, image_name_prefix examples:
+        * ubuntu-os-cloud, ubuntu-1404
+        * centos-cloud, centos-7
+        """
+        latest_image = None
+        page_token = None
+        while not latest_image:
+            response = self._compute.images().list(
+                project=base_image_project,
+                maxResults=500,
+                pageToken=page_token,
+                filter='name eq {}.*'.format(image_name_prefix)
+            ).execute()
+
+            latest_image = next((image for image in response.get('items', [])
+                                 if 'deprecated' not in image),
+                                None)
+            page_token = response.get('nextPageToken')
+            if not page_token:
+                break
+        return latest_image
+
+
+    def _get_state(self, instance_name, ip_address):
+        # The minimum amount of data necessary to keep machine state
+        # everything else can be pulled from the config
+
+        data = {
+            'ip_address': ip_address,
+            'instance_name': instance_name,
+            'distro': self.distro,
+        }
+        data['distribution'] = linux_distribution(self.username, ip_address)
+        data['os_release'] = os_release(self.username, ip_address)
+        with open(STATE_FILE_NAME, 'w') as f:
+            json.dump(data, f)

--- a/bookshelf/api_v3/gce.py
+++ b/bookshelf/api_v3/gce.py
@@ -21,6 +21,7 @@ class GCEConfiguration(PClass):
     private_key_filename = field(factory=unicode, mandatory=True)
     project = field(factory=unicode, mandatory=True)
     machine_type = field(factory=unicode, mandatory=True)
+    image_basename = field(type=unicode, mandatory=True, factory=unicode)
     username = field(factory=unicode, mandatory=True)
     description = field(factory=unicode, mandatory=True)
     instance_name = field(factory=unicode, mandatory=True)
@@ -71,8 +72,8 @@ class GCE(object):
         return self.config.description
 
     @property
-    def name(self):
-        return self.state.instance_name
+    def image_basename(self):
+        return self.config.image_basename
 
     @property
     def ip_address(self):

--- a/bookshelf/api_v3/gce.py
+++ b/bookshelf/api_v3/gce.py
@@ -3,7 +3,7 @@ import uuid
 
 from zope.interface import implementer, provider
 from pyrsistent import PClass, field
-from oauth2client.client import GoogleCredentials
+from oauth2client.client import SignedJwtAssertionCredentials
 from googleapiclient import discovery
 from googleapiclient.errors import HttpError
 
@@ -20,11 +20,13 @@ class DistributionConfiguration(PClass):
 
 
 class GCEConfiguration(PClass):
-    machine_type = field(factory=unicode, mandatory=True)
-    username = field(factory=unicode, mandatory=True)
+    credentials_private_key = field(factory=unicode, mandatory=True)
+    credentials_email = field(factory=unicode, mandatory=True)
     public_key_filename = field(factory=unicode, mandatory=True)
     private_key_filename = field(factory=unicode, mandatory=True)
     project = field(factory=unicode, mandatory=True)
+    machine_type = field(factory=unicode, mandatory=True)
+    username = field(factory=unicode, mandatory=True)
     ubuntu1404 = field(type=DistributionConfiguration, mandatory=True)
     centos7 = field(type=DistributionConfiguration, mandatory=True)
 
@@ -54,6 +56,10 @@ class GCE(object):
         return self.config.project
 
     @property
+    def username(self):
+        return self.config.username
+
+    @property
     def zone(self):
         return self.state.zone
 
@@ -72,6 +78,10 @@ class GCE(object):
     @property
     def ip_address(self):
         return self.state.ip_address
+
+    @property
+    def key_filename(self):
+        return self.config.private_key_filename
 
     @classmethod
     def create_from_config(cls, config, distro, region):
@@ -307,7 +317,13 @@ class GCE(object):
         log_green("Instance has booted")
 
     def _get_gce_compute(self):
-        credentials = GoogleCredentials.get_application_default()
+        credentials = SignedJwtAssertionCredentials(
+            self.config.credentials_email,
+            self.config.credentials_private_key,
+            scope=[
+                u"https://www.googleapis.com/auth/compute",
+            ]
+        )
         compute = discovery.build('compute', 'v1', credentials=credentials)
         return compute
 

--- a/bookshelf/api_v3/rackspace.py
+++ b/bookshelf/api_v3/rackspace.py
@@ -1,0 +1,235 @@
+import socket
+from sys import exit
+from time import sleep
+import uuid
+
+from zope.interface import implementer, provider
+from pyrsistent import PClass, field
+import pyrax
+from novaclient.exceptions import NotFound
+from fabric.api import sudo, settings
+from fabric.context_managers import hide
+
+from bookshelf.api_v1 import (
+    wait_for_ssh, linux_distribution, os_release
+)
+from bookshelf.api_v2.logging_helpers import log_green, log_yellow, log_red
+from cloud_instance import ICloudInstance, ICloudInstanceFactory
+
+
+class DistributionConfiguration(PClass):
+    ami = field(factory=unicode, mandatory=True)
+    description = field(factory=unicode, mandatory=True)
+    instance_name = field(factory=unicode, mandatory=True)
+
+
+class RackspaceConfiguration(PClass):
+    username = field(factory=unicode, mandatory=True)
+    disk_name = field(factory=unicode, mandatory=True)
+    disk_size = field(factory=unicode, mandatory=True)
+    instance_type = field(factory=unicode, mandatory=True)
+    region = field(factory=unicode, mandatory=True)
+    key_pair = field(factory=unicode, mandatory=True)
+    public_key_filename = field(factory=unicode, mandatory=True)
+    private_key_filename = field(factory=unicode, mandatory=True)
+    access_key_id = field(factory=unicode, mandatory=True)
+    secret_access_key = field(factory=unicode, mandatory=True)
+    auth_system = field(factory=unicode, mandatory=True)
+    auth_auth_url = field(factory=unicode, mandatory=True)
+    tenant = field(factory=unicode, mandatory=True)
+    security_groups = field(factory=unicode, mandatory=True)
+    ubuntu1404 = field(type=DistributionConfiguration, mandatory=True)
+    centos7 = field(type=DistributionConfiguration, mandatory=True)
+
+
+class RackspaceState(PClass):
+    instance_name = field(factory=unicode, mandatory=True)
+    ip_address = field(factory=unicode, mandatory=True)
+    distro = field(factory=unicode, mandatory=True)
+    region = field(factory=unicode, mandatory=True)
+
+
+@implementer(ICloudInstance)
+@provider(ICloudInstanceFactory)
+class Rackspace(object):
+
+    cloud = 'rackspace'
+
+    def __init__(self, config, state):
+        self.config = RackspaceConfiguration.create(config)
+        distro = state.distro
+        self.distro_config = getattr(self.config, distro)
+        self.state = state
+        self._nova = self._connect_to_rackspace()
+
+    @property
+    def distro(self):
+        return self.state.distro
+
+    @property
+    def description(self):
+        return self.distro_config.description
+
+    @property
+    def ip_address(self):
+        return self.state.ip_address
+
+    @property
+    def instance_name(self):
+        return self.state.instance_name
+
+    @classmethod
+    def create_from_config(cls, config, distro, region):
+        instance_name = "{}-{}".format(
+            config[distro]['instance_name'],
+            unicode(uuid.uuid4())
+        )
+        state = RackspaceState(
+            instance_name=instance_name,
+            ip_address="",
+            distro=distro,
+            region=region
+        )
+        instance = Rackspace(config, state)
+        instance.upload_key()
+        instance._create_server()
+        return instance
+
+    def upload_key(self):
+
+        try:
+            log_green("Checking for key pair {}".format(self.config.key_pair))
+            self._nova.keypairs.get(self.config.key_pair)
+            log_green("Key pair exists in rackspace")
+        except NotFound:
+            log_green("Creating key pair {}".format(self.config.key_pair))
+            with open(self.config.public_key_filename) as keyfile:
+                self._nova.keypairs.create(self.config.key_pair,
+                                           keyfile.read())
+
+    @classmethod
+    def create_from_saved_state(cls, config, saved_state):
+        state = RackspaceState.create(saved_state)
+        instance = Rackspace(config, state)
+        server = instance._ensure_instance_running()
+        # if we've restarted a terminated server, the ip address
+        # might have changed from our saved state, get the
+        # networking info and resave the state
+        instance._set_instance_networking(server)
+        return instance
+
+    def _ensure_instance_running(self):
+        server = self._nova.servers.find(name=self.instance_name)
+        if server.status != "ACTIVE":
+            server.start()
+        return server
+
+    def _create_server(self):
+        log_yellow("Creating Rackspace instance...")
+        flavor = self._nova.flavors.find(name=self.config.instance_type)
+        image = self._nova.images.find(name=self.distro_config.ami)
+        server = self._nova.servers.create(
+            name=self.instance_name,
+            flavor=flavor.id,
+            image=image.id,
+            region=self.config.region,
+            availability_zone=self.config.region,
+            key_name=self.config.key_pair
+        )
+
+        while server.status == 'BUILD':
+            log_yellow("Waiting for build to finish...")
+            sleep(10)
+            server = self._nova.servers.get(server.id)
+        # check for errors
+        if server.status != 'ACTIVE':
+            log_red("Error creating rackspace instance")
+            exit(1)
+        self._set_instance_networking(server)
+
+
+    def _set_instance_networking(self, server):
+        ip_address = server.accessIPv4
+        if ip_address is None:
+            log_red('No IP address assigned')
+            exit(1)
+        self.state = self.state.transform(['ip_address'], ip_address)
+        wait_for_ssh(ip_address)
+        log_green('Connected to server with IP address {0}.'.format(
+            ip_address)
+        )
+
+
+    def _connect_to_rackspace(self):
+        """ returns a connection object to Rackspace  """
+        pyrax.set_setting('identity_type', 'rackspace')
+        pyrax.set_default_region(self.state.region)
+        pyrax.set_credentials(self.config.access_key_id,
+                              self.config.secret_access_key)
+        nova = pyrax.connect_to_cloudservers(region=self.state.region)
+        return nova
+
+
+    def create_image(self, image_name):
+        server = self._nova.servers.find(name=self.instance_name)
+        image_id = self._nova.servers.create_image(server.id,
+                                                   image_name=image_name)
+        image = self._nova.images.get(image_id).status.lower()
+        log_green('creating rackspace image...')
+        sleep_time = 20
+        elapsed = 0
+        while self._nova.images.get(image_id).status.lower() not in ['active',
+                                                                     'error']:
+            log_green('building rackspace image, '
+                      'this could take a bit: elapsed {}s.'.format(elapsed))
+            sleep(20)
+            elapsed += sleep_time
+        if image == 'error':
+            log_red('error creating image')
+            exit(1)
+
+        log_green('finished image: %s' % image_id)
+        return image_id
+
+
+    def destroy(self):
+        server = self._nova.servers.find(name=self.instance_name)
+        log_yellow('deleting rackspace instance ...')
+        server.delete()
+
+        try:
+            while True:
+                server = self._nova.servers.get(server.id)
+                log_yellow('waiting for deletion ...')
+                sleep(5)
+        except NotFound:
+            pass
+        log_green('The server has been deleted')
+
+
+    def down(self):
+        server = self._nova.servers.find(name=self.instance_name)
+
+        if server.status == "ACTIVE":
+            with settings(hide('warnings', 'running', 'stdout', 'stderr'),
+                          warn_only=True, capture=True):
+                sudo('/sbin/halt')
+
+        while server.status == "ACTIVE":
+            log_yellow("Instance state: %s" % server.status)
+            sleep(10)
+            server = self._nova.servers.get(server.id)
+        log_yellow("Instance state: %s" % server.status)
+
+
+    def get_state(self):
+        # The minimum amount of data necessary to keep machine state
+        # everything else can be pulled from the config
+
+        data = {
+            'instance_name': self.state.instance_name,
+            'ip_address': self.state.ip_address,
+            'distro': self.state.distro,
+            'region': self.state.region,
+        }
+        return data

--- a/bookshelf/api_v3/rackspace.py
+++ b/bookshelf/api_v3/rackspace.py
@@ -16,8 +16,6 @@ from cloud_instance import ICloudInstance, ICloudInstanceFactory, Distribution
 
 class RackspaceConfiguration(PClass):
     username = field(factory=unicode, mandatory=True)
-    disk_name = field(factory=unicode, mandatory=True)
-    disk_size = field(factory=unicode, mandatory=True)
     instance_type = field(factory=unicode, mandatory=True)
     key_pair = field(factory=unicode, mandatory=True)
     public_key_filename = field(factory=unicode, mandatory=True)
@@ -25,9 +23,6 @@ class RackspaceConfiguration(PClass):
     image_basename = field(type=unicode, mandatory=True, factory=unicode)
     access_key_id = field(factory=unicode, mandatory=True)
     secret_access_key = field(factory=unicode, mandatory=True)
-    auth_system = field(factory=unicode, mandatory=True)
-    auth_auth_url = field(factory=unicode, mandatory=True)
-    tenant = field(factory=unicode, mandatory=True)
     ami = field(factory=unicode, mandatory=True)
     description = field(factory=unicode, mandatory=True)
     instance_name = field(factory=unicode, mandatory=True)
@@ -209,7 +204,9 @@ class Rackspace(object):
 
         if server.status == "ACTIVE":
             with settings(hide('warnings', 'running', 'stdout', 'stderr'),
-                          warn_only=True, capture=True):
+                          warn_only=True, capture=True,
+                          key_filename=self.key_filename, user=self.username,
+                          host_string=self.ip_address):
                 sudo('/sbin/halt')
 
         while server.status == "ACTIVE":

--- a/bookshelf/api_v3/rackspace.py
+++ b/bookshelf/api_v3/rackspace.py
@@ -22,6 +22,7 @@ class RackspaceConfiguration(PClass):
     key_pair = field(factory=unicode, mandatory=True)
     public_key_filename = field(factory=unicode, mandatory=True)
     private_key_filename = field(factory=unicode, mandatory=True)
+    image_basename = field(type=unicode, mandatory=True, factory=unicode)
     access_key_id = field(factory=unicode, mandatory=True)
     secret_access_key = field(factory=unicode, mandatory=True)
     auth_system = field(factory=unicode, mandatory=True)
@@ -67,8 +68,8 @@ class Rackspace(object):
         return self.state.ip_address
 
     @property
-    def name(self):
-        return self.state.instance_name
+    def image_basename(self):
+        return self.config.image_basename
 
     @property
     def region(self):

--- a/bookshelf/api_v3/rackspace.py
+++ b/bookshelf/api_v3/rackspace.py
@@ -25,7 +25,6 @@ class RackspaceConfiguration(PClass):
     disk_name = field(factory=unicode, mandatory=True)
     disk_size = field(factory=unicode, mandatory=True)
     instance_type = field(factory=unicode, mandatory=True)
-    region = field(factory=unicode, mandatory=True)
     key_pair = field(factory=unicode, mandatory=True)
     public_key_filename = field(factory=unicode, mandatory=True)
     private_key_filename = field(factory=unicode, mandatory=True)
@@ -64,6 +63,10 @@ class Rackspace(object):
         return Distribution(self.state.distro)
 
     @property
+    def username(self):
+        return self.config.username
+
+    @property
     def description(self):
         return self.distro_config.description
 
@@ -74,6 +77,10 @@ class Rackspace(object):
     @property
     def name(self):
         return self.state.instance_name
+
+    @property
+    def key_filename(self):
+        return self.config.private_key_filename
 
     @classmethod
     def create_from_config(cls, config, distro, region):
@@ -130,8 +137,8 @@ class Rackspace(object):
             name=self.state.instance_name,
             flavor=flavor.id,
             image=image.id,
-            region=self.config.region,
-            availability_zone=self.config.region,
+            region=self.state.region,
+            availability_zone=self.state.region,
             key_name=self.config.key_pair
         )
 

--- a/bookshelf/api_v3/rackspace.py
+++ b/bookshelf/api_v3/rackspace.py
@@ -27,7 +27,6 @@ class RackspaceConfiguration(PClass):
     auth_system = field(factory=unicode, mandatory=True)
     auth_auth_url = field(factory=unicode, mandatory=True)
     tenant = field(factory=unicode, mandatory=True)
-    security_groups = field(factory=unicode, mandatory=True)
     ami = field(factory=unicode, mandatory=True)
     description = field(factory=unicode, mandatory=True)
     instance_name = field(factory=unicode, mandatory=True)

--- a/bookshelf/tests/api_v3/test_cloud.py
+++ b/bookshelf/tests/api_v3/test_cloud.py
@@ -1,0 +1,336 @@
+import unittest
+
+from subprocess import check_output
+from uuid import uuid4
+import yaml
+import os
+
+from bookshelf.api_v3.cloud_instance import Distribution, ICloudInstance
+from bookshelf.api_v3.rackspace import Rackspace, RackspaceConfiguration
+from bookshelf.api_v3.gce import GCE, GCEConfiguration
+from bookshelf.api_v3.ec2 import EC2, EC2Configuration, EC2Credentials
+from zope.interface.verify import verifyObject
+
+
+class CloudInstanceTestMixin(object):
+    """
+    Mixin test structure for tests that verify a cloud instance is functional.
+
+    Assumes the following members are initialized in setUp():
+
+    self.instance_factory: An ICloudInstanceFactory provider.
+    self.config: A valid configuration for the ICloudInstanceFactory provider.
+    self.distribution: The distribution that the config launches.
+    self.region: A valid region  for the ICloudInstanceFactory provider.
+    """
+
+    def _make_instance(self):
+        """
+        Create an instance using the factory, from member variables that must
+        be set by the subclass.
+        """
+        instance = self.instance_factory.create_from_config(
+            self.config, self.distribution, self.region
+        )
+        self.addCleanup(instance.destroy)
+        return instance
+
+    def _restore_from_state(self, state):
+        """
+        Create an instance object by restoring from state.
+
+        Does not clean up by destroying the instance, because this never
+        creates an instance, merely re-connects to one created by something
+        else.
+        """
+        instance = self.instance_factory.create_from_saved_state(
+            self.config, state
+        )
+        return instance
+
+    def _instance_sanity_check(self, instance):
+        """
+        Verify that the instance implements the ``ICloudInstance`` interface,
+        and the information it provides can be used to ssh to the instance.
+        """
+        verifyObject(ICloudInstance, instance)
+        _TEST_STRING = b"Hello12345"
+        output = check_output([
+            "ssh", "-i", instance.key_filename,
+            "-o", "UserKnownHostsFile=/dev/null",
+            "-o", "StrictHostKeyChecking=no",
+            "%s@%s" % (instance.username, instance.ip_address),
+            "echo", _TEST_STRING])
+        self.assertIn(_TEST_STRING, output)
+
+    def _assert_instances_are_same(self, instance1, instance2,
+                                   verify_ips=True):
+        """
+        Assert that two instance objects probably refer to the same instance.
+
+        :param bool verify_ips: Whether we should verify that the instances
+            have the same IP. Can be false in situations where you are
+            comparing an instance from before an up/down cycle to one after an
+            up/down cycle.
+        """
+        self.assertEquals(instance1.distro, instance2.distro)
+        self.assertEquals(instance1.username, instance2.username)
+        self.assertEquals(instance1.image_basename, instance2.image_basename)
+        self.assertEquals(instance1.region, instance2.region)
+        self.assertEquals(instance1.key_filename, instance2.key_filename)
+        if verify_ips:
+            self.assertEquals(instance1.ip_address, instance2.ip_address)
+
+    def test_instance_factory_and_instance(self):
+        """
+        This is one large test that verifies all of the functionality of a
+        specific implementation of an instance factory and the instances that
+        it creates.
+
+        Done as one large test rather than many little ones because it takes a
+        lot of time to setup the initial instance. The bad part about this is
+        it might be a bit time consuming to debug and reproduce failures.
+        """
+        instance = self._make_instance()
+        self._instance_sanity_check(instance)
+
+        up_state = instance.get_state()
+
+        restored_instance = self._restore_from_state(up_state)
+        self._instance_sanity_check(restored_instance)
+        self._assert_instances_are_same(instance, restored_instance)
+
+        instance.down()
+        down_state = instance.get_state()
+
+        # Up the instance by reviving the state.
+        revived_instance = self._restore_from_state(down_state)
+        self._instance_sanity_check(revived_instance)
+        self._assert_instances_are_same(
+            instance, revived_instance, verify_ips=False)
+
+        unique_id = revived_instance.create_image(
+            'testing-image-%s' % str(uuid4()))
+
+        print "Would you mind deleting %s for me?" % unique_id
+
+
+class MissingConfigError(Exception):
+    """
+    Error that is raised to indicate that some required configuration key was
+    not specified.
+    """
+    pass
+
+
+def _extract_substructure(base, substructure):
+    """
+    Assuming that substructure is a possibly nested dictionary, return a new
+    dictionary with the same keys (and subkeys) as substructure, but extract
+    the leaf values from base.
+
+    This is used to extract and verify a configuration from a yaml blob.
+    """
+    if (type(substructure) is not dict and
+            type(base) is not dict):
+        return base
+    if type(base) is not dict:
+        raise MissingConfigError(
+            "Found non-dict value {} when expecting a sub-configuration "
+            "{}.".format(repr(base), repr(substructure)))
+    if type(substructure) is not dict:
+        raise MissingConfigError(
+            "Found dict value {} when expecting a simple configuration value "
+            "{}.".format(repr(base), repr(substructure)))
+    try:
+        return {key: _extract_substructure(base[key], substructure[key])
+                for key in substructure.keys()}
+    except KeyError as e:
+        raise MissingConfigError(
+            "Missing key {} in configuration".format(e.args[0]))
+
+
+def _extract_substructure_from_yaml(filename, substructure):
+    """
+    Parse filename as a yaml file, an extract the keys in substructure, which
+    may be a nested dictionary.
+    """
+    with open(filename) as f:
+        config = yaml.safe_load(f)
+    try:
+        return _extract_substructure(config, substructure)
+    except MissingConfigError as e:
+        print (
+            'Skipping test: could not get configuration: {}\n\n'
+            'In order to run this test, add ensure {} has structure '
+            'like:\n\n{}'.format(
+                e.message,
+                filename,
+                yaml.dump(substructure, default_flow_style=False)))
+        raise unittest.SkipTest()
+
+
+def _get_yaml_config(substructure):
+    """
+    Extract the keys from the config in substructure, which may be a nested
+    dictionary.
+
+    Raises a ``unittest.SkipTest`` if the substructure is not found in the
+    configuration.
+
+    This can be used to load credentials all at once for testing purposes.
+    """
+    _ENV_VAR = 'ACCEPTANCE_YAML'
+    filename = os.environ.get(_ENV_VAR)
+    if not filename:
+        print (
+            'Must set {} to an acceptance.yaml file ('
+            'http://doc-dev.clusterhq.com/gettinginvolved/appendix.html#acceptance-testing-configuration'  #noqa
+            ') plus additional keys in order to run this test.'.format(
+                _ENV_VAR))
+        raise unittest.SkipTest()
+    with open(filename) as f:
+        config = yaml.safe_load(f)
+    try:
+        return _extract_substructure(config, substructure)
+    except MissingConfigError as e:
+        print (
+            'Skipping test: could not get configuration: {}\n\n'
+            'In order to run this test, add ensure {} has structure '
+            'like:\n\n{}'.format(
+                e.message,
+                filename,
+                yaml.dump(substructure, default_flow_style=False)))
+        raise unittest.SkipTest()
+
+
+class RackspaceTests(unittest.TestCase, CloudInstanceTestMixin):
+    """
+    Tests for rackspace.
+    """
+
+    def setUp(self):
+        super(RackspaceTests, self).setUp()
+
+        credentials = _get_yaml_config(
+            {
+                'rackspace': {
+                    'keyname': '<Rackspace keypair name>',
+                    'username': '<Rackspace username>',
+                    'key': '<Rackspace secret auth key>',
+                },
+                'ssh_keys': {
+                    'rackspace': {
+                        'private_key_file': '<path-to-private-keypair-file>',
+                        'public_key_file': '<path-to-corresponding-public-key>'
+                    }
+                }
+            }
+        )
+
+        ssh_keys = credentials["ssh_keys"]["rackspace"]
+        self.config = RackspaceConfiguration(
+            username='root',
+            instance_type='1GB Standard Instance',
+            key_pair=credentials["rackspace"]["keyname"],
+            public_key_filename=ssh_keys["public_key_file"],
+            private_key_filename=ssh_keys["private_key_file"],
+            access_key_id=credentials["rackspace"]["username"],
+            secret_access_key=credentials["rackspace"]["key"],
+            ami='CentOS 7 (PVHVM)',
+            description='rackspace-test-instance-description',
+            image_basename='rackspace-test-image',
+            instance_name='rackspace-test-instance'
+        ).serialize()
+        self.distribution = Distribution.CENTOS7
+        self.region = 'HKG'
+        self.instance_factory = Rackspace
+
+
+class GCETests(unittest.TestCase, CloudInstanceTestMixin):
+    """
+    Tests for GCE.
+    """
+
+    def setUp(self):
+        super(GCETests, self).setUp()
+
+        credentials = _get_yaml_config(
+            {
+                'gce': {
+                    'project': '<GCE project>',
+                },
+                'ssh_keys': {
+                    'gce': {
+                        'private_key_file': '<path-to-private-key-file>',
+                        'public_key_file': '<path-to-corresponding-public-key>'
+                    }
+                }
+            }
+        )
+
+        keys = credentials["ssh_keys"]["gce"]
+        self.config = GCEConfiguration(
+            public_key_filename=keys["public_key_file"],
+            private_key_filename=keys["private_key_file"],
+            project=credentials["gce"]["project"],
+            machine_type="n1-standard-1",
+            image_basename="gce-test-image",
+            username="gce-username-xyz",
+            description="gce-test-description",
+            instance_name="gce-test-instance",
+            base_image_prefix='ubuntu-1404',
+            base_image_project='ubuntu-os-cloud'
+        ).serialize()
+        self.distribution = Distribution.UBUNTU1404
+        self.region = 'us-central1-f'
+        self.instance_factory = GCE
+
+
+class EC2Tests(unittest.TestCase, CloudInstanceTestMixin):
+    """
+    Tests for EC2.
+    """
+
+    def setUp(self):
+        super(EC2Tests, self).setUp()
+
+        credentials = _get_yaml_config(
+            {
+                'aws': {
+                    'access_key': '<AWS-ACCESS-KEY>',
+                    'secret_access_token': '<AWS-SECRET-ACCESS-TOKEN>',
+                    'keyname': '<aws-us-west-2-ssh-keypair-name>',
+                },
+                'ssh_keys': {
+                    'aws': {
+                        'private_key_file': '<path-to-private-key-for-keypair>'
+                    }
+                }
+            }
+        )
+
+        self.config = EC2Configuration(
+            credentials=EC2Credentials(
+                access_key_id=credentials["aws"]["access_key"],
+                secret_access_key=credentials["aws"]["secret_access_token"]
+            ),
+            username='centos',
+            disk_name='/dev/sda1',
+            disk_size='48',
+            instance_name='ec2-test-instance',
+            tags={'name': 'test-instance-with-tags'},
+            image_description='ec2-test-description',
+            image_basename='ec2-image-basename',
+            ami='ami-d440a6e7',
+            key_filename=credentials["ssh_keys"]["aws"]["private_key_file"],
+            key_pair=credentials["aws"]["keyname"],
+            instance_type='t2.medium',
+            security_groups=['ssh']
+        ).serialize()
+        self.distribution = Distribution.CENTOS7
+        self.region = 'us-west-2'
+        self.instance_factory = EC2
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bookshelf/tests/api_v3/test_interfaces.py
+++ b/bookshelf/tests/api_v3/test_interfaces.py
@@ -1,0 +1,23 @@
+
+import unittest
+
+from zope.interface.verify import verifyObject, verifyClass
+
+from bookshelf.api_v3.gce import GCE
+from bookshelf.api_v3.cloud_instance import (
+    ICloudInstanceFactory,
+    ICloudInstance
+)
+
+
+class TestGCEInterfaces(unittest.TestCase):
+
+    def test_gce_provides_cloud_instance_factory(self):
+        verifyObject(ICloudInstanceFactory, GCE)
+
+    def test_gce_implements_cloud_instance(self):
+        verifyClass(ICloudInstance, GCE)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=4, failfast=True)

--- a/bookshelf/tests/api_v3/test_interfaces.py
+++ b/bookshelf/tests/api_v3/test_interfaces.py
@@ -3,9 +3,9 @@ import unittest
 
 from zope.interface.verify import verifyObject, verifyClass
 
-from bookshelf.api_v3.gce import GCE
-from bookshelf.api_v3.ec2 import EC2
-from bookshelf.api_v3.rackspace import Rackspace
+from bookshelf.api_v3.gce import GCEInstance
+from bookshelf.api_v3.ec2 import EC2Instance
+from bookshelf.api_v3.rackspace import RackspaceInstance
 from bookshelf.api_v3.cloud_instance import (
     ICloudInstanceFactory,
     ICloudInstance
@@ -15,28 +15,28 @@ from bookshelf.api_v3.cloud_instance import (
 class TestGCEInterfaces(unittest.TestCase):
 
     def test_gce_provides_cloud_instance_factory(self):
-        verifyObject(ICloudInstanceFactory, GCE)
+        verifyObject(ICloudInstanceFactory, GCEInstance)
 
     def test_gce_implements_cloud_instance(self):
-        verifyClass(ICloudInstance, GCE)
+        verifyClass(ICloudInstance, GCEInstance)
 
 
 class TestEC2Interfaces(unittest.TestCase):
 
     def test_ec2_provides_cloud_instance_factory(self):
-        verifyObject(ICloudInstanceFactory, EC2)
+        verifyObject(ICloudInstanceFactory, EC2Instance)
 
     def test_ec2_implements_cloud_instance(self):
-        verifyClass(ICloudInstance, EC2)
+        verifyClass(ICloudInstance, EC2Instance)
 
 
 class TestRackspaceInterfaces(unittest.TestCase):
 
     def test_rackspace_provides_cloud_instance_factory(self):
-        verifyObject(ICloudInstanceFactory, Rackspace)
+        verifyObject(ICloudInstanceFactory, RackspaceInstance)
 
     def test_rackspaceee_implements_cloud_instance(self):
-        verifyClass(ICloudInstance, Rackspace)
+        verifyClass(ICloudInstance, RackspaceInstance)
 
 
 if __name__ == '__main__':

--- a/bookshelf/tests/api_v3/test_interfaces.py
+++ b/bookshelf/tests/api_v3/test_interfaces.py
@@ -4,6 +4,7 @@ import unittest
 from zope.interface.verify import verifyObject, verifyClass
 
 from bookshelf.api_v3.gce import GCE
+from bookshelf.api_v3.ec2 import EC2
 from bookshelf.api_v3.cloud_instance import (
     ICloudInstanceFactory,
     ICloudInstance
@@ -17,6 +18,15 @@ class TestGCEInterfaces(unittest.TestCase):
 
     def test_gce_implements_cloud_instance(self):
         verifyClass(ICloudInstance, GCE)
+
+
+class TestEC2Interfaces(unittest.TestCase):
+
+    def test_gce_provides_cloud_instance_factory(self):
+        verifyObject(ICloudInstanceFactory, EC2)
+
+    def test_gce_implements_cloud_instance(self):
+        verifyClass(ICloudInstance, EC2)
 
 
 if __name__ == '__main__':

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,6 +13,7 @@ flake8
 oauth2client
 google-api-python-client
 zope.interface
+pyrsistent
 # paramiko doesn't support recent SSH macs
 # https://github.com/paramiko/paramiko/pull/581
 -e git+https://github.com/ericwb/paramiko.git@rfc6668#egg=paramiko

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@ docker-fabric
 fabric
 cuisine==0.7.11
 pyrax
-enum
+flufl.enum
 boto
 moto
 watchdog

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,6 +2,7 @@ docker-fabric
 fabric
 cuisine==0.7.11
 pyrax
+enum
 boto
 moto
 watchdog
@@ -9,6 +10,9 @@ python-subunit
 junitxml
 ipython
 flake8
+oauth2client
+google-api-python-client
+zope.interface
 # paramiko doesn't support recent SSH macs
 # https://github.com/paramiko/paramiko/pull/581
 -e git+https://github.com/ericwb/paramiko.git@rfc6668#egg=paramiko

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 docker-fabric
 fabric
 cuisine==0.7.11
-enum
+flufl.enum
 pyrax
 boto
 moto

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,9 @@ pyrax
 boto
 moto
 ipython
+oauth2client
+google-api-python-client
+zope.interface
 # paramiko doesn't support recent SSH macs
 # https://github.com/paramiko/paramiko/pull/581
 -e git+https://github.com/ericwb/paramiko.git@rfc6668#egg=paramiko

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ ipython
 oauth2client
 google-api-python-client
 zope.interface
+pyrsistent
 # paramiko doesn't support recent SSH macs
 # https://github.com/paramiko/paramiko/pull/581
 -e git+https://github.com/ericwb/paramiko.git@rfc6668#egg=paramiko

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 docker-fabric
 fabric
 cuisine==0.7.11
+enum
 pyrax
 boto
 moto

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,6 @@ setup(
               'bookshelf.tests.api_v2', ],
     install_requires=['cuisine', 'fabric', 'pyrax', 'boto',
                       'google-api-python-client', 'oauth2client',
-                      'zope.interface', 'enum', 'pyrsistent'],
+                      'zope.interface', 'flufl.enum', 'pyrsistent'],
     license='Apache License, Version 2.0',
 )

--- a/setup.py
+++ b/setup.py
@@ -4,16 +4,17 @@ except ImportError:
     from distutils.core import setup
 
 
-setup(name='Bookshelf',
-      version='2.0.4',
-      description='Bookshelf of Fabric functions',
-      author='ClusterHQ',
-      author_email='nospam@clusterhq.com',
-      url='https://www.github.com/ClusterHQ/Bookshelf/',
-      packages=['bookshelf', 'bookshelf.api_v2', 'bookshelf.tests',
-                'bookshelf.tests.api_v2', ],
-      install_requires=['cuisine', 'fabric', 'pyrax', 'boto',
-                        'google-api-python-client', 'oauth2client',
-                        'zope.interface', 'enum'],
-      license='Apache License, Version 2.0',
-     )
+setup(
+    name='Bookshelf',
+    version='2.0.4',
+    description='Bookshelf of Fabric functions',
+    author='ClusterHQ',
+    author_email='nospam@clusterhq.com',
+    url='https://www.github.com/ClusterHQ/Bookshelf/',
+    packages=['bookshelf', 'bookshelf.api_v2', 'bookshelf.tests',
+              'bookshelf.tests.api_v2', ],
+    install_requires=['cuisine', 'fabric', 'pyrax', 'boto',
+                      'google-api-python-client', 'oauth2client',
+                      'zope.interface', 'enum', 'pyrsistent'],
+    license='Apache License, Version 2.0',
+)

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,6 @@ setup(name='Bookshelf',
                 'bookshelf.tests.api_v2', ],
       install_requires=['cuisine', 'fabric', 'pyrax', 'boto',
                         'google-api-python-client', 'oauth2client',
-                        'zope.interface'],
+                        'zope.interface', 'enum'],
       license='Apache License, Version 2.0',
      )

--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,13 @@ except ImportError:
 
 setup(
     name='Bookshelf',
-    version='2.0.4',
+    version='3.0.0',
     description='Bookshelf of Fabric functions',
     author='ClusterHQ',
     author_email='nospam@clusterhq.com',
     url='https://www.github.com/ClusterHQ/Bookshelf/',
-    packages=['bookshelf', 'bookshelf.api_v2', 'bookshelf.tests',
-              'bookshelf.tests.api_v2', ],
+    packages=['bookshelf', 'bookshelf.api_v2', 'bookshelf.api_v3',
+              'bookshelf.tests', 'bookshelf.tests.api_v2', ],
     install_requires=['cuisine', 'fabric', 'pyrax', 'boto',
                       'google-api-python-client', 'oauth2client',
                       'zope.interface', 'flufl.enum', 'pyrsistent'],

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(name='Bookshelf',
       packages=['bookshelf', 'bookshelf.api_v2', 'bookshelf.tests',
                 'bookshelf.tests.api_v2', ],
       install_requires=['cuisine', 'fabric', 'pyrax', 'boto',
-                        'google-api-python-client', 'oauth2client'],
+                        'google-api-python-client', 'oauth2client',
+                        'zope.interface'],
       license='Apache License, Version 2.0',
      )


### PR DESCRIPTION
We've refactored the code to create, destroy and down instances, as well as create images for all cloud providers.  All the new code is hidden in `bookshelf/api_v3`.  The biggest change is moving to classes that represent cloud instances with a consistent interface (in `bookshelf/api_v3/cloud_instance.py`) across those classes.  

Each class has a constructor to create a cloud instance from a user-supplied configuration (`create_from_config`) or bring up a saved instance (running or not running) from a configuration and previously saved state information (`create_from_saved_state`).  The saved state data mostly just lists the instance name you've already provisioned.

Overall, when making changes to these classes, we found that propagating those changes across clouds was transparent and easy.  The classes should be able to support provisioning images for other purposes in the future.
